### PR TITLE
Fix crash in _map_age_dead_critters

### DIFF
--- a/src/object.cc
+++ b/src/object.cc
@@ -2146,6 +2146,8 @@ Object* objectFindFirst()
         return NULL;
     }
 
+    gObjectFindTile++;
+
     while (objectListNode != NULL) {
         if (artIsObjectTypeHidden(FID_TYPE(objectListNode->obj->fid)) == 0) {
             gObjectFindLastObjectListNode = objectListNode;
@@ -2199,6 +2201,7 @@ Object* objectFindFirstAtElevation(int elevation)
             if (object->elevation == elevation) {
                 if (!artIsObjectTypeHidden(FID_TYPE(object->fid))) {
                     gObjectFindLastObjectListNode = objectListNode;
+                    gObjectFindTile++;
                     return object;
                 }
             }

--- a/src/object.cc
+++ b/src/object.cc
@@ -109,6 +109,10 @@ static int _centerToUpperLeft = 0;
 static int gObjectFindElevation = 0;
 
 // 0x519634
+/** 
+ * This variable holds "tile where to lookup when current list ends".
+ * 
+*/
 static int gObjectFindTile = 0;
 
 // 0x519638
@@ -2247,6 +2251,8 @@ Object* objectFindNextAtElevation()
 Object* objectFindFirstAtLocation(int elevation, int tile)
 {
     gObjectFindElevation = elevation;
+
+    // Meaningless assignment because it is not used in objectFindNextAtLocation
     gObjectFindTile = tile;
 
     ObjectListNode* objectListNode = gObjectListHeadByTile[tile];


### PR DESCRIPTION
This PR fixes crashing in `_map_age_dead_critters` function because the same object destroyed twice.

I have a save file on Fallout Of Nevada where it happens. Probably reproduceable via keeping corpse on the lowest-index tile and waiting for a while.

It was caused by `objectFindFirst`/`objectFindNext` functions which returned the same object twice due to off-by-one error in `gObjectFindTile` variable.

After calling `objectFindFirst()` function `gObjectFindTile` variable holds index of tile where object was found. After few calls to `objectFindNext` when this tile is exhausted we do postfix increment on `gObjectFindTile` so we start to fetch objects from the same tile. When tile is exhausted second time then we jump to the next tile because `gObjectFindTile` already incremented in the first exhausting.

So, for this function we consider `gObjectFindTile` as a "tile where to lookup when current list ends". It should always be next tile.

Of course it is possible to keep `gObjectFindTile` meaning as "tile where we currently iterating" but this will lead to more changes in `objectFindNext` function, not just changing postfix increment into prefix but also checking `gObjectFindTile` is still in the range.

This PR affects `objectFindFirst`/`objectFindNext` and `objectFindFirstAtElevation`/`objectFindNextAtElevation` functions. Other function `objectFindFirstAtLocation` sets `gObjectFindTile` variable but `objectFindNextAtLocation` is not using it. 


@alexbatalov 