### PR TITLE
Allow messageIndex to be zero (but still not negavite)

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -2987,7 +2987,7 @@ static void opGetMessageString(Program* program)
     int messageListIndex = programStackPopInteger(program);
 
     char* string;
-    if (messageIndex >= 1) {
+    if (messageIndex >= 0) {
         string = _scr_get_msg_str_speech(messageListIndex, messageIndex, 1);
         if (string == NULL) {
             debugPrint("\nError: No message file EXISTS!: index %d, line %d", messageListIndex, messageIndex);


### PR DESCRIPTION
Fallout Of Nevada have dialog string with index zero at least in one place. Original game works fine so this PR just makes it to be in sync with original game.
We still check that index is not negative value, just allow message index to be zero

@alexbatalov