### PR TITLE
Remove trailing comma after reading strParseIntWithKey

### DIFF
--- a/src/string_parsers.cc
+++ b/src/string_parsers.cc
@@ -208,6 +208,10 @@ int strParseIntWithKey(char** stringPtr, const char* key, int* valuePtr, const c
     *(str + v4) = tmp2;
     *(str + v2) = tmp1;
 
+    if (**stringPtr == ',') {
+        *stringPtr = *stringPtr + 1;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Original game in function `0x004AFF7C` adds `1` to the final result so it automatically skips last comma.
```C
...
      if ( !strcmp_(v10, v5) )
      {
         *v4 += v15 + 1; // <- Here it is
         v18 = 1;
         *v15 = atoi_(v14);
      }
...
```

This works perfectly fine if there is a trailing comma, but if this part was last part then it is a problem.
This PR moves string pointer only if there is a comma.

This solved issues with Fallout: Nevada random encounters

@alexbatalov