### PR TITLE
Asyncfetchfs clear file contents on stream close

### DIFF
--- a/os/web/asyncfetchfs.js
+++ b/os/web/asyncfetchfs.js
@@ -392,6 +392,9 @@ const ASYNCFETCHFS = {
                 stream.node.mode === ASYNCFETCHFS.FILE_MODE &&
                 stream.node.openedCount === 0
             ) {
+                // Sometimes game can open the same file multiple times
+                // We rely on service worker caching so it will not be
+                // downloaded via network next time
                 stream.node.contents = null;
             }
         },

--- a/os/web/asyncfetchfs.js
+++ b/os/web/asyncfetchfs.js
@@ -17,7 +17,7 @@ const EINVAL = 22;
  * @param {number | null} size
  */
 function createDummyInflator(size) {
-    if (size !== null && !isNaN(size)) {        
+    if (size !== null && !isNaN(size)) {
         const buffer = new Uint8Array(size);
         let pos = 0;
         return {
@@ -207,6 +207,7 @@ const ASYNCFETCHFS = {
             node.size = 4096;
             node.contents = {};
         }
+        node.openedCount = 0;
         if (parent) {
             parent.contents[name] = node;
         }
@@ -303,6 +304,7 @@ const ASYNCFETCHFS = {
         open: function (stream) {
             if (Asyncify.state == Asyncify.State.Normal) {
                 if (stream.node.contents) {
+                    stream.node.openedCount++;
                     return;
                 }
             }
@@ -381,7 +383,17 @@ const ASYNCFETCHFS = {
                 }
 
                 node.contents = data;
+                node.openedCount++;
             });
+        },
+        close: function (stream) {
+            stream.node.openedCount--;
+            if (
+                stream.node.mode === ASYNCFETCHFS.FILE_MODE &&
+                stream.node.openedCount === 0
+            ) {
+                stream.node.contents = null;
+            }
         },
     },
 };

--- a/os/web/index.sw.js
+++ b/os/web/index.sw.js
@@ -27,7 +27,7 @@ const CACHE_FILES = [
     ".",
 ];
 
-const VERSION = 24;
+const VERSION = 25;
 
 const ENGINE_CACHE_NAME = "engine";
 


### PR DESCRIPTION
In order to not to keep in memory all files let's clear file contents when stream is closed. We have service worker so file will not be downloaded via network each time