### PR TITLE
Fix WASM memory OOB hazards in object preload path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,5 +83,6 @@
         "unordered_set": "cpp",
         "variant": "cpp"
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/build.debug/compile_commands.json"
 }

--- a/manual-deploy.sh
+++ b/manual-deploy.sh
@@ -15,7 +15,7 @@ docker run --rm --user $(id -u):$(id -g) -v $(pwd):$(pwd) -w $(pwd) \
   sh -c 'mkdir -p build && cd build && 
         export SOURCE_MAP_BASE=https://fallout-nevada.ru/ &&
         export EM_CACHE=$(pwd)/build/emcache && 
-        emcmake cmake -DCMAKE_BUILD_TYPE="Release" ../ && 
+        emcmake cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../ && 
         emmake make VERBOSE=1 -j 8'
 
 echo ""
@@ -28,7 +28,7 @@ docker run --rm --user $(id -u):$(id -g) -v $(pwd):$(pwd) -w $(pwd) \
   sh -c 'mkdir -p build.debug && cd build.debug && 
         export SOURCE_MAP_BASE=https://fallout-nevada.ru/ &&
         export EM_CACHE=$(pwd)/build.debug/emcache && 
-        emcmake cmake -DCMAKE_BUILD_TYPE="Debug" ../ && 
+        emcmake cmake -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../ && 
         emmake make VERBOSE=1 -j 8'
 
 echo ""

--- a/src/object.cc
+++ b/src/object.cc
@@ -59,6 +59,7 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect);
 static void objectDrawOutline(Object* object, Rect* rect);
 static void _obj_render_object(Object* object, Rect* rect, int light);
 static int _obj_preload_sort(const void* a1, const void* a2);
+static int objectGetPreloadTypeOrder(int fid);
 
 // 0x5195F8
 static bool gObjectsInitialized = false;
@@ -124,6 +125,9 @@ static int* gObjectFids = nullptr;
 
 // 0x519640
 static int gObjectFidsLength = 0;
+
+// Capacity of gObjectFids.
+static int gObjectFidsCapacity = 0;
 
 // 0x51964C
 static Rect _light_rect[9] = {
@@ -493,15 +497,20 @@ static int objectLoadAllInternal(File* stream)
 
     if (gObjectFids != nullptr) {
         internal_free(gObjectFids);
+        gObjectFids = nullptr;
     }
+
+    gObjectFidsLength = 0;
+    gObjectFidsCapacity = 0;
 
     if (objectCount != 0) {
         gObjectFids = (int*)internal_malloc(sizeof(*gObjectFids) * objectCount);
-        memset(gObjectFids, 0, sizeof(*gObjectFids) * objectCount);
         if (gObjectFids == nullptr) {
             return -1;
         }
-        gObjectFidsLength = 0;
+
+        memset(gObjectFids, 0, sizeof(*gObjectFids) * objectCount);
+        gObjectFidsCapacity = objectCount;
     }
 
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {
@@ -535,7 +544,11 @@ static int objectLoadAllInternal(File* stream)
             }
 
             objectListNode->obj->outline = 0;
-            gObjectFids[gObjectFidsLength++] = objectListNode->obj->fid;
+            if (gObjectFids != nullptr && gObjectFidsLength < gObjectFidsCapacity) {
+                gObjectFids[gObjectFidsLength++] = objectListNode->obj->fid;
+            } else {
+                debugPrint("\nError: object fid preload list overflow");
+            }
 
             if (objectListNode->obj->sid != -1) {
                 Script* script;
@@ -3180,6 +3193,13 @@ void _obj_preload_art_cache(int flags)
         return;
     }
 
+    if (gObjectFidsLength <= 0) {
+        internal_free(gObjectFids);
+        gObjectFids = nullptr;
+        gObjectFidsCapacity = 0;
+        return;
+    }
+
     unsigned char arr[4096];
     memset(arr, 0, sizeof(arr));
 
@@ -3210,16 +3230,8 @@ void _obj_preload_art_cache(int flags)
     qsort(gObjectFids, gObjectFidsLength, sizeof(*gObjectFids), _obj_preload_sort);
 
     int v11 = gObjectFidsLength;
-    int v12 = gObjectFidsLength;
-
-    if (FID_TYPE(gObjectFids[v12 - 1]) == OBJ_TYPE_WALL) {
-        int objectType = OBJ_TYPE_ITEM;
-        do {
-            v11--;
-            objectType = FID_TYPE(gObjectFids[v12 - 1]);
-            v12--;
-        } while (objectType == OBJ_TYPE_WALL);
-        v11++;
+    while (v11 > 0 && FID_TYPE(gObjectFids[v11 - 1]) == OBJ_TYPE_WALL) {
+        v11--;
     }
 
     CacheEntry* cache_handle;
@@ -3244,7 +3256,7 @@ void _obj_preload_art_cache(int flags)
         }
     }
 
-    for (int i = v11; i < gObjectFidsLength; i++) {
+    for (int i = std::max(v11, 1); i < gObjectFidsLength; i++) {
         if (gObjectFids[i - 1] != gObjectFids[i]) {
             if (artLock(gObjectFids[i], &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
@@ -3256,6 +3268,7 @@ void _obj_preload_art_cache(int flags)
     gObjectFids = nullptr;
 
     gObjectFidsLength = 0;
+    gObjectFidsCapacity = 0;
 }
 
 // 0x48CB88
@@ -5205,8 +5218,8 @@ static int _obj_preload_sort(const void* a1, const void* a2)
     int v1 = *(int*)a1;
     int v2 = *(int*)a2;
 
-    int v3 = _cd_order[FID_TYPE(v1)];
-    int v4 = _cd_order[FID_TYPE(v2)];
+    int v3 = objectGetPreloadTypeOrder(v1);
+    int v4 = objectGetPreloadTypeOrder(v2);
 
     int cmp = v3 - v4;
     if (cmp != 0) {
@@ -5225,6 +5238,16 @@ static int _obj_preload_sort(const void* a1, const void* a2)
 
     cmp = ((v1 & 0xFF0000) >> 16) - (((v2 & 0xFF0000) >> 16));
     return cmp;
+}
+
+static int objectGetPreloadTypeOrder(int fid)
+{
+    int fidType = FID_TYPE(fid);
+    if (fidType < 0 || fidType >= static_cast<int>(sizeof(_cd_order) / sizeof(_cd_order[0]))) {
+        return 0;
+    }
+
+    return _cd_order[fidType];
 }
 
 Object* objectTypedFindById(int id, int type)

--- a/src/object.cc
+++ b/src/object.cc
@@ -3193,7 +3193,7 @@ void _obj_preload_art_cache(int flags)
         return;
     }
 
-    if (gObjectFidsLength <= 0) {
+    if (gObjectFidsLength == 0) {
         internal_free(gObjectFids);
         gObjectFids = nullptr;
         gObjectFidsCapacity = 0;


### PR DESCRIPTION
## Summary
This PR hardens object-art preload logic in `src/object.cc` to prevent undefined memory reads that can surface as WebAssembly runtime traps such as:
- `RuntimeError: memory access out of bounds`
- `RuntimeError: Out of bounds memory access`
- related secondary faults (`call_indirect to a null table entry`, `function signature mismatch`) after memory corruption.

The changes are fully defensive and keep existing behavior for valid data.

## What Was Happening
During map load, the engine collects object FIDs into `gObjectFids`, sorts them, then preloads art to warm cache (`_obj_preload_art_cache`).

There were multiple unsafe indexing paths in this flow:

1. **Unchecked FID type index in sort comparator**
   - `_obj_preload_sort` used `_cd_order[FID_TYPE(fid)]` directly.
   - `_cd_order` has 9 elements, but `FID_TYPE` comes from packed runtime/map data and can be outside `[0..8]` for malformed/unexpected values.
   - In native builds this is UB; in WASM it frequently manifests as hard traps (`memory access out of bounds`).

2. **Potential out-of-bounds write when collecting preload FIDs**
   - `gObjectFids[gObjectFidsLength++] = ...` had no capacity check.
   - If loaded object count diverges from header count (corrupted map or mismatch), this can write past allocation.

3. **Potential negative index/read in wall-tail split logic**
   - `_obj_preload_art_cache` had reverse scanning logic that could underflow edge cases and later relied on `i - 1` access patterns.
   - This was rewritten to monotonic bounded logic.

4. **Unsafe empty-list assumptions**
   - Cache preload path assumed non-empty list and touched first element (`*gObjectFids`) without full empty-state protection.
   - Empty allocated lists now cleanly free/reset and return.

## Why It Appears in Production as WASM OOB
WebAssembly enforces strict linear-memory bounds checks at runtime. Any UB-style pointer/array overflow that might silently pass in native builds becomes an immediate runtime exception in browsers.

This code executes during map/object preload and can be hit across different routes and browsers, which matches the observed Sentry profile for frequent cross-browser `memory access out of bounds` groups.

## Fixes Implemented
### 1) Safe FID type ordering helper
- Added `objectGetPreloadTypeOrder(int fid)`.
- Validates `FID_TYPE(fid)` against `_cd_order` bounds and returns a safe fallback order for unknown types.
- `_obj_preload_sort` now uses this helper instead of direct unchecked indexing.

### 2) Preload FID capacity tracking and guarded writes
- Added `gObjectFidsCapacity`.
- Reset pointer/length/capacity consistently when reinitializing.
- On load, set capacity from header count and guard each append with `gObjectFidsLength < gObjectFidsCapacity`.
- On overflow condition, log and avoid OOB write.

### 3) Hardened empty/preload cleanup path
- `_obj_preload_art_cache` now:
  - returns immediately if pointer is null;
  - if list length is zero, frees `gObjectFids`, resets state, and returns;
  - avoids touching list element 0 unless list is non-empty.

### 4) Safer wall-tail split iteration
- Replaced reverse do/while tail scan with bounded `while (v11 > 0 && ...)`.
- Adjusted second loop start index (`std::max(v11, 1)`) to avoid `i - 1` underflow.

## Behavior and Risk
- No gameplay logic changes intended.
- Changes are defensive around preload and sorting only.
- For valid map/object data, behavior should remain identical except improved robustness under unexpected/corrupt data.

## Validation
Built successfully with the same Docker emsdk flow used in `manual-deploy.sh`:
- Release (`emscripten/emsdk:3.1.74`): ✅
- Debug (`emscripten/emsdk:3.1.74`): ✅

## Notes
This addresses concrete memory-safety hazards in one hot preload path strongly correlated with WebAssembly OOB error classes. Additional OOB groups may still exist in other modules, but this removes a clear set of crash vectors in `object.cc`.
